### PR TITLE
Correctly parse large ratingCount

### DIFF
--- a/amazon_3b1b_review_confidence.js
+++ b/amazon_3b1b_review_confidence.js
@@ -91,7 +91,7 @@
                         logDebugMessage("Matched on product regex.");
                         // extract values
                         let ratingValue = parseFloat(match[1].replace(",", ".")); // must swap out localised decimals to literals (e.g. "4,5" -> "4.5")
-                        let ratingCount = parseInt(countTextNode.innerText.replace(",", "").replace(".", "")); // must strip periods and commas out for localised integers (e.g. "1,589" -> "1589" and "1.589" -> "1589")
+                        let ratingCount = parseInt(countTextNode.innerText.replaceAll(",", "").replaceAll(".", "")); // must strip periods and commas out for localised integers (e.g. "1,589" -> "1589" and "1.589" -> "1589")
                         logDebugMessage(`Rating is ${ratingValue} out of 5 with ${ratingCount} ratings.`);
                         // calculate the confidence values
                         let [confidenceRatingPercent, originalRatingPercent, correctionAmount] = calculateConfidenceRating(ratingValue, ratingCount);
@@ -131,7 +131,7 @@
                         logDebugMessage(match);
                         // extract values
                         let ratingValue = parseFloat(match[1].replace(",", ".")); // must swap out localised decimals to literals (e.g. "4,5" -> "4.5")
-                        let ratingCount = parseInt(match[3].replace(",", "").replace(".", "")); // must strip periods and commas out for localised integers (e.g. "1,589" -> "1589" and "1.589" -> "1589")
+                        let ratingCount = parseInt(match[3].replaceAll(",", "").replaceAll(".", "")); // must strip periods and commas out for localised integers (e.g. "1,589" -> "1589" and "1.589" -> "1589")
                         logDebugMessage(`Rating is ${ratingValue} out of 5 with ${ratingCount} ratings.`);
                         // find the average rating and review count text elements in the hover
                         let ratingTextNode = mutation.target.querySelector('[data-hook=acr-average-stars-rating-text]');


### PR DESCRIPTION
Multiple commas and periods may be present in rating count of products.